### PR TITLE
deps: add renovate config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "webpack": "^5.74.0"
       },
       "peerDependencies": {
-        "@bpmn-io/form-js": "^0.9.0"
+        "@bpmn-io/form-js": ">= 0.9"
       }
     },
     "example": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "webpack": "^5.74.0"
   },
   "peerDependencies": {
-    "@bpmn-io/form-js": "^0.9.0"
+    "@bpmn-io/form-js": ">= 0.9"
   },
   "sideEffects": [
     "*.css"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>bpmn-io/renovate-config:recommended",
+    ":reviewer(camunda/modeling-dev)"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "@bpmn-io/form-js.*"
+      ],
+      "groupName": "modeling dependencies",
+      "groupSlug": "modeling"
+    }
+  ]
+}


### PR DESCRIPTION
* [x] <del>Drop dependabot (.github/dependabot.yml)</del>
* [x] Enable repository via [renovate app configuration](https://github.com/apps/renovate) ==> Requested!
* [x] Create renovate.json / [modify to base on top of shared config](https://github.com/bpmn-io/bpmn-js/blob/develop/renovate.json)
* [ ] Work through these massive chunks of PRs

----

I believe we should do this, as this is meant to be a product-like library as `camunda-[bpmn|dmn]-js`. Let me know if you have any objections. 