### PR TITLE
Fix scrolling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+public
+dist

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": [
+    "plugin:bpmn-io/node",
     "plugin:bpmn-io/browser"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "karma start",
     "build": "rollup -c",
     "build:watch": "rollup -cw",
-    "lint": "eslint src",
+    "lint": "eslint .",
     "start": "run-p build:watch start:example",
     "start:example": "npm start --workspace=example",
     "dev": "npm test -- --auto-watch --no-single-run",

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "packageRules": [
     {
       "matchPackagePatterns": [
+        "form-js.*",
         "@bpmn-io/form-js.*"
       ],
       "groupName": "modeling dependencies",

--- a/src/components/PlaygroundComponent.css
+++ b/src/components/PlaygroundComponent.css
@@ -122,6 +122,10 @@
   height: 100%;
 }
 
+.cfp-root .cm-editor .cm-scroller {
+  overflow: auto !important;
+}
+
 .cfp-root .cfp-palette {
   background-color: var(--palette-background-color);
   overflow: auto;

--- a/src/components/PlaygroundComponent.css
+++ b/src/components/PlaygroundComponent.css
@@ -113,6 +113,10 @@
   margin: auto;
 }
 
+.cfp-root .fjs-editor-container {
+  display: inherit;
+}
+
 .cfp-root .cm-editor {
   background-color: var(--cm-background-color);
   height: 100%;


### PR DESCRIPTION
Closes #11 

This 
* lints all source files properly
* fixes scrolling for the form editor
* fixes scrolling for the code mirror editors

Example: `--form-container-max-width` set to 300px.

![image](https://user-images.githubusercontent.com/9433996/195549245-5a5eb86c-cf40-4379-9126-56a16adab25f.png)

