### PR TITLE
style: do not display preview and output in design mode

### DIFF
--- a/src/components/PlaygroundComponent.css
+++ b/src/components/PlaygroundComponent.css
@@ -95,10 +95,6 @@
   flex: 1;
 }
 
-.cfp-root:not(.cfp-open-preview) [data-idx="form-input"] {
-  display: none;
-}
-
 .cfp-root [data-idx="form-preview"] {
   border-top: none;
   flex: 2;
@@ -106,6 +102,12 @@
 
 .cfp-root [data-idx="form-output"] {
   flex: 1;
+}
+
+.cfp-root:not(.cfp-open-preview) [data-idx="form-input"],
+.cfp-root:not(.cfp-open-preview) [data-idx="form-output"],
+.cfp-root:not(.cfp-open-preview) [data-idx="form-preview"] {
+  display: none;
 }
 
 .cfp-root .fjs-container {


### PR DESCRIPTION
Closes #17

![Kapture 2022-10-21 at 11 35 36](https://user-images.githubusercontent.com/9433996/197164896-e3e6f4c5-66dd-4a22-8e0e-c23cef966ea2.gif)

We removed this while fixing the flickering problem, but having this doesn't call problems, so it might be an oversight.

![Kapture 2022-10-21 at 11 37 58](https://user-images.githubusercontent.com/9433996/197165164-d6397fe6-0baf-4751-9dd4-02f4cb6819c7.gif)
