### PR TITLE
feat: add missing playground API

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ const eventBus = formPlayground.get('eventBus');
 ```
 
 
+### `CamundaFormPlayground#getDataEditor() => JSONEditor`
+
+Get the embedded input data editor.
+
+```javascript
+const dataEditor = formPlayground.getDataEditor();
+
+const data = dataEditor.getValue();
+```
+
+
 ### `CamundaFormPlayground#getEditor() => FormEditor`
 
 Get the embedded form editor.
@@ -117,6 +128,30 @@ Get the embedded form editor.
 const editor = formPlayground.getEditor();
 
 editor.on('selection.changed', () => { ... });
+```
+
+
+### `CamundaFormPlayground#getForm() => Form`
+
+Get the embedded preview form.
+
+```javascript
+const form = formPlayground.getForm();
+
+form.on('submit', event => {
+  console.log('Form <submit>', event);
+});
+```
+
+
+### `CamundaFormPlayground#getResultView() => JSONEditor`
+
+Get the embedded output data view.
+
+```javascript
+const resultView = formPlayground.getResultView();
+
+const data = resultView.getValue();
 ```
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -92,39 +92,31 @@ export function CamundaFormPlayground(options) {
     }
   };
 
-  this.get = safeRef(function(module, strict) {
-    return playgroundRef.get(module, strict);
-  });
+  this.get = safeRef((module, strict) => playgroundRef.get(module, strict));
 
   /**
    * @param {string|Array<string>} [containers]
    */
-  this.open = safeRef(function(containers) {
-    return playgroundRef.open(containers);
-  });
+  this.open = safeRef((containers) => playgroundRef.open(containers));
 
   /**
    * @param {string|Array<string>} [containers]
    */
-  this.collapse = safeRef(function(containers) {
-    return playgroundRef.collapse(containers);
-  });
+  this.collapse = safeRef((containers) => playgroundRef.collapse(containers));
 
-  this.setSchema = safeRef(function(schema) {
-    return playgroundRef.setSchema(schema);
-  });
+  this.setSchema = safeRef((schema) => playgroundRef.setSchema(schema));
 
-  this.getSchema = safeRef(function() {
-    return playgroundRef.getSchema();
-  });
+  this.getSchema = safeRef(() => playgroundRef.getSchema());
 
-  this.saveSchema = safeRef(function() {
-    return playgroundRef.saveSchema();
-  });
+  this.saveSchema = safeRef(() => playgroundRef.saveSchema());
 
-  this.getEditor = safeRef(function() {
-    return playgroundRef.getEditor();
-  });
+  this.getDataEditor = safeRef(() => playgroundRef.getDataEditor());
+
+  this.getEditor = safeRef(() => playgroundRef.getEditor());
+
+  this.getForm = safeRef((name, strict) => playgroundRef.getForm(name, strict));
+
+  this.getResultView = safeRef(() => playgroundRef.getResultView());
 
   this._onInit = function(_ref) {
     playgroundRef = _ref;

--- a/test/spec/CamundaFormPlayground.spec.js
+++ b/test/spec/CamundaFormPlayground.spec.js
@@ -302,8 +302,11 @@ describe('CamundaFormPlayground', function() {
 
     [
       'collapse',
-      'getSchema',
+      'getDataEditor',
       'getEditor',
+      'getForm',
+      'getResultView',
+      'getSchema',
       'open',
       'saveSchema',
       'setSchema',


### PR DESCRIPTION
This adds some missing methods from the core `form-js-playground` that were recently added (cf. https://github.com/bpmn-io/form-js/pull/364)

* `#getDataEditor`
* `#getForm`
* `#getResultView`

Related to https://github.com/camunda/camunda-modeler/issues/3247