### PR TITLE
feat: make `#once` generally available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,13 @@ export function CamundaFormPlayground(options) {
   this.off = emitter.off;
   this.fire = emitter.emit;
 
+  // added due to current limitation of <mitt.once>
+  // cf. https://github.com/developit/mitt/issues/136
+  this.once = function(type, fn) {
+    emitter.on(type, fn);
+    emitter.on(type, emitter.off.bind(emitter, type, fn));
+  };
+
   this.destroy = function() {
     const parent = container.parentNode;
     render(null, container);
@@ -145,16 +152,12 @@ export async function createCamundaFormPlayground(options) {
 
   return new Promise((resolve, reject) => {
 
-    // only listen once
-    // added due to current limitation of <mitt.once>
-    // cf. https://github.com/developit/mitt/issues/136
     const onInit = () => {
-      playground.off('formPlayground.init', onInit);
       return resolve(playground);
     };
 
     try {
-      playground.on('formPlayground.init', onInit);
+      playground.once('formPlayground.init', onInit);
     } catch (err) {
       return reject(err);
     }

--- a/test/spec/CamundaFormPlayground.spec.js
+++ b/test/spec/CamundaFormPlayground.spec.js
@@ -138,6 +138,30 @@ describe('CamundaFormPlayground', function() {
   });
 
 
+  it('#once', async function() {
+
+    // given
+    const spy = sinon.spy();
+
+    // when
+    await waitFor(async () => {
+      playground = await createCamundaFormPlayground({
+        container
+      });
+    });
+
+    // when
+    playground.once('formPlayground.rendered', spy);
+
+    playground.fire('formPlayground.rendered');
+    playground.fire('formPlayground.rendered');
+    playground.fire('formPlayground.rendered');
+
+    // then
+    expect(spy).to.have.been.calledOnce;
+  });
+
+
   describe('#attachTo', async function() {
 
     let parent;


### PR DESCRIPTION
We already use this internally, but let's make this also available generally. 