### PR TITLE
style: style drag container border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to [@camunda/form-playground](https://github.com/camunda/for
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.3.0
+
+* `FEAT`: expose `once` event handler ([`9433e9ac`](https://github.com/camunda/form-playground/commit/9433e9ace2b2302631b2806dcf7dc0f8a71581ef))
+* `FEAT`: integrate `diagram-js/ui/lib` ([#28](https://github.com/camunda/form-playground/issues/28))
+* `FIX`: correctly apply fonts ([`83a3a4fe`](https://github.com/camunda/form-playground/commit/83a3a4fede1d01132c6fbcc3a778e952af9bd9bf))
+* `FIX`: style drag container ([#41](https://github.com/camunda/form-playground/pull/41))
+
+
 ## 0.2.1
 
 * `FIX`: fixed horizontal code editor scrolling ([`a5f661c9`](https://github.com/camunda/form-playground/commit/a5f661c9bad6353cba6677c3e75a872df210361e))

--- a/src/components/PlaygroundComponent.css
+++ b/src/components/PlaygroundComponent.css
@@ -33,9 +33,11 @@
   --properties-arrow-hover-background-color: var(--color-grey-225-10-90);
   --container-background-color: var(--color-white);
   --cm-background-color: var(--color-white);
+  --drag-container-border-color: var(--color-grey-225-10-80);
 
   --form-container-max-width: 1200px;
   --collapsible-cursor: default;
+  --drag-cursor: default;
 
   --font-family: 'IBM Plex Sans', system-ui, Arial, sans-serif;
   --font-family-monospace: 'IBM Plex Mono', monospace;
@@ -203,4 +205,23 @@
   --input-background-color: var(--properties-input-background-color);
   --group-background-color: var(--properties-group-background-color);
   --arrow-hover-background-color: var(--properties-arrow-hover-background-color);
+}
+
+/**
+ * Custom Dragula Styles
+ *
+ * @pinussilvestrus: remove me once this is fixed: https://github.com/bpmn-io/form-js/issues/462
+ */
+.cfp-root .fjs-children.fjs-drag-container {
+  border: 2px dashed transparent;
+}
+
+.gu-unselectable .cfp-root .fjs-children.fjs-drag-container {
+  cursor: var(--drag-cursor);
+}
+
+@media only screen and (min-width: 1650px) {
+  .gu-unselectable .cfp-root:not(.cfp-open-preview) .fjs-children.fjs-drag-container {
+    border: 2px dashed var(--drag-container-border-color);
+  }
 }


### PR DESCRIPTION
Related to https://github.com/bpmn-io/form-js/issues/461

This adds a visual indicator for the drag/drop container on bigger screen sizes. Note it currently works on the _total screen size_ of the whole playground, not only of the editor. We could use the [`container-name` + query feature](https://developer.mozilla.org/en-US/docs/Web/CSS/container-name) for that, but this is only supported by [the absolute latest browser versions](https://caniuse.com/?search=container-name).

Demo: https://fixup-drag-container--camunda-form-playground.netlify.app/

Let me know what you think 👍 

![Kapture 2022-12-13 at 14 54 16](https://user-images.githubusercontent.com/9433996/207348355-cb7a9cff-43a4-440a-b74b-68b8df53bac6.gif)


