### PR TITLE
chore: fail on build warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "dependencies": {
         "classnames": "^2.3.1",
-        "diagram-js": "^11.1.0",
+        "diagram-js": "^11.4.4",
         "min-dash": "^4.0.0",
         "min-dom": "^4.0.0",
         "mitt": "^3.0.0"
@@ -494,9 +494,9 @@
       }
     },
     "node_modules/@bpmn-io/diagram-js-ui": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.0.tgz",
-      "integrity": "sha512-5uP4xgJHynGwq5SsyzzEGdRdhFUu/jfh/0tfcxH/K+W2TE7cdBde45kQdh601xzvCet+RrL8PY82uxs5D0d7qA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.2.tgz",
+      "integrity": "sha512-IgOIxOwoqsFB2mMPdXtcbPVPjdYkZ3huW7ipowYLhg5jdRGHlBronQ+LER+lfWro6sPtzEsw7qX8D8Yq9M2S5g==",
       "dependencies": {
         "htm": "^3.1.1",
         "preact": "^10.11.2"
@@ -3705,11 +3705,11 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.1.0.tgz",
-      "integrity": "sha512-LDfSPHpFaXiu2LkElf2iIBmM0M9iyN189Tt0xk/GsMqm468BUXsDKBSZEqwSUPGOPd5+afCtZIS4SRlr/vgZwg==",
+      "version": "11.4.4",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.4.4.tgz",
+      "integrity": "sha512-utKzP3zqun6DwWiGc62aJpxsRxwhFQjiTaFJEHZS3XKimPvlbsEN4dqAAIUqQ5pFjtNNlNTZ2dkF0JsjJpwqCg==",
       "dependencies": {
-        "@bpmn-io/diagram-js-ui": "^0.2.0",
+        "@bpmn-io/diagram-js-ui": "^0.2.2",
         "clsx": "^1.2.1",
         "css.escape": "^1.5.1",
         "didi": "^9.0.0",
@@ -10876,9 +10876,9 @@
       }
     },
     "@bpmn-io/diagram-js-ui": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.0.tgz",
-      "integrity": "sha512-5uP4xgJHynGwq5SsyzzEGdRdhFUu/jfh/0tfcxH/K+W2TE7cdBde45kQdh601xzvCet+RrL8PY82uxs5D0d7qA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.2.tgz",
+      "integrity": "sha512-IgOIxOwoqsFB2mMPdXtcbPVPjdYkZ3huW7ipowYLhg5jdRGHlBronQ+LER+lfWro6sPtzEsw7qX8D8Yq9M2S5g==",
       "requires": {
         "htm": "^3.1.1",
         "preact": "^10.11.2"
@@ -11008,7 +11008,7 @@
         "cross-env": "^7.0.3",
         "css-loader": "^6.7.1",
         "del": "6.1.1",
-        "diagram-js": "^11.1.0",
+        "diagram-js": "^11.4.4",
         "eslint": "^8.22.0",
         "eslint-plugin-bpmn-io": "^1.0.0",
         "execa": "^1.0.0",
@@ -11352,9 +11352,9 @@
           }
         },
         "@bpmn-io/diagram-js-ui": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.0.tgz",
-          "integrity": "sha512-5uP4xgJHynGwq5SsyzzEGdRdhFUu/jfh/0tfcxH/K+W2TE7cdBde45kQdh601xzvCet+RrL8PY82uxs5D0d7qA==",
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.2.tgz",
+          "integrity": "sha512-IgOIxOwoqsFB2mMPdXtcbPVPjdYkZ3huW7ipowYLhg5jdRGHlBronQ+LER+lfWro6sPtzEsw7qX8D8Yq9M2S5g==",
           "requires": {
             "htm": "^3.1.1",
             "preact": "^10.11.2"
@@ -13861,11 +13861,11 @@
           "dev": true
         },
         "diagram-js": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.1.0.tgz",
-          "integrity": "sha512-LDfSPHpFaXiu2LkElf2iIBmM0M9iyN189Tt0xk/GsMqm468BUXsDKBSZEqwSUPGOPd5+afCtZIS4SRlr/vgZwg==",
+          "version": "11.4.4",
+          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.4.4.tgz",
+          "integrity": "sha512-utKzP3zqun6DwWiGc62aJpxsRxwhFQjiTaFJEHZS3XKimPvlbsEN4dqAAIUqQ5pFjtNNlNTZ2dkF0JsjJpwqCg==",
           "requires": {
-            "@bpmn-io/diagram-js-ui": "^0.2.0",
+            "@bpmn-io/diagram-js-ui": "^0.2.2",
             "clsx": "^1.2.1",
             "css.escape": "^1.5.1",
             "didi": "^9.0.0",
@@ -21403,11 +21403,11 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.1.0.tgz",
-      "integrity": "sha512-LDfSPHpFaXiu2LkElf2iIBmM0M9iyN189Tt0xk/GsMqm468BUXsDKBSZEqwSUPGOPd5+afCtZIS4SRlr/vgZwg==",
+      "version": "11.4.4",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.4.4.tgz",
+      "integrity": "sha512-utKzP3zqun6DwWiGc62aJpxsRxwhFQjiTaFJEHZS3XKimPvlbsEN4dqAAIUqQ5pFjtNNlNTZ2dkF0JsjJpwqCg==",
       "requires": {
-        "@bpmn-io/diagram-js-ui": "^0.2.0",
+        "@bpmn-io/diagram-js-ui": "^0.2.2",
         "clsx": "^1.2.1",
         "css.escape": "^1.5.1",
         "didi": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "license": "MIT",
   "dependencies": {
     "classnames": "^2.3.1",
-    "diagram-js": "^11.1.0",
+    "diagram-js": "^11.4.4",
     "min-dash": "^4.0.0",
     "min-dom": "^4.0.0",
     "mitt": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "all": "run-s lint test build",
     "test": "karma start",
-    "build": "rollup -c",
+    "build": "rollup -c --failAfterWarnings",
     "build:watch": "rollup -cw",
     "lint": "eslint .",
     "start": "run-p build:watch start:example",

--- a/test/spec/components/CollapsedPreview.spec.js
+++ b/test/spec/components/CollapsedPreview.spec.js
@@ -8,7 +8,7 @@ import {
   render
 } from '@testing-library/preact/pure';
 
-import { html } from 'htm/preact';
+import { html } from 'diagram-js/lib/ui';
 
 import {
   query as domQuery

--- a/test/spec/components/CollapsiblePanel.spec.js
+++ b/test/spec/components/CollapsiblePanel.spec.js
@@ -8,7 +8,7 @@ import {
   render
 } from '@testing-library/preact/pure';
 
-import { html } from 'htm/preact';
+import { html } from 'diagram-js/lib/ui';
 
 import {
   classes as domClasses,

--- a/test/spec/components/PlaygroundComponent.spec.js
+++ b/test/spec/components/PlaygroundComponent.spec.js
@@ -10,7 +10,7 @@ import {
   waitFor
 } from '@testing-library/preact/pure';
 
-import { html } from 'htm/preact';
+import { html } from 'diagram-js/lib/ui';
 
 import {
   classes as domClasses,


### PR DESCRIPTION
Related to https://github.com/bpmn-io/diagram-js-ui/issues/12

We need to make sure we do not publish bundles that have warnings. For more context, see this [Slack thread](https://camunda.slack.com/archives/C043W5V88M7/p1673344558906539).