### PR TITLE
feat: use `drag.*` events to set drop target styles

### DIFF
--- a/src/components/PlaygroundComponent.css
+++ b/src/components/PlaygroundComponent.css
@@ -220,7 +220,7 @@
 }
 
 @media only screen and (min-width: 1650px) {
-  .cfp-root:not(.cfp-open-preview) .gu-unselectable .fjs-children.fjs-drop-container-vertical  {
+  .cfp-root:not(.cfp-open-preview).cfp-dragging .fjs-children.fjs-drop-container-vertical  {
     border-color: var(--drag-container-border-color);
   }
 }

--- a/test/spec/CamundaFormPlayground.spec.js
+++ b/test/spec/CamundaFormPlayground.spec.js
@@ -344,4 +344,61 @@ describe('CamundaFormPlayground', function() {
 
   });
 
+
+  describe('dragging behavior', function() {
+
+    let playground;
+
+    beforeEach(async function() {
+      await waitFor(async () => {
+        playground = await createCamundaFormPlayground({
+          container,
+          schema
+        });
+      });
+    });
+
+    it('should add drop target styles on <drag.hover>', async function() {
+
+      // given
+      const formEditor = playground.getEditor();
+      formEditor.get('eventBus').fire('formEditor.rendered');
+
+      // when
+      formEditor.get('eventBus').fire('drag.hover', {
+        container: domQuery('.fjs-drop-container-horizontal', container)
+      });
+
+      // then
+      const root = domQuery('.cfp-root', container);
+
+      expect(root.classList.contains('cfp-dragging')).to.be.true;
+    });
+
+
+    it('should remove drop target styles on <drag.out>', async function() {
+
+      // given
+      const formEditor = playground.getEditor();
+      formEditor.get('eventBus').fire('formEditor.rendered');
+
+      // when
+      formEditor.get('eventBus').fire('drag.hover', {
+        container: domQuery('.fjs-drop-container-horizontal', container)
+      });
+
+      const root = domQuery('.cfp-root', container);
+
+      // assume
+      expect(root.classList.contains('cfp-dragging')).to.be.true;
+
+      // and when
+      formEditor.get('eventBus').fire('drag.out');
+
+      // then
+      expect(root.classList.contains('cfp-dragging')).to.be.false;
+    });
+
+  });
+
 });


### PR DESCRIPTION
Closes #53

This is to make this behavior agnostic from the dragging library we use under the hood but use our own internal events. The styles of the border is unchanged.

Demo: https://53-replace-dragula-behavior--camunda-form-playground.netlify.app/

![image](https://github.com/camunda/form-playground/assets/9433996/1f66d208-6f44-4ccf-8371-481291a8575e)
