### PR TITLE
deps: add auto reviewer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,9 @@
     "github>bpmn-io/renovate-config:recommended",
     ":reviewer(camunda/modeling-dev)"
   ],
+  "reviewers": [
+    "team:hto-frontend"
+  ],
   "packageRules": [
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
This sets auto reviewers to @camunda/hto-frontend. Once we decide on this, we can enable this in our other projects where we use Renovate (cf. https://github.com/orgs/camunda/teams/hto-frontend/repositories)

Related to https://github.com/bpmn-io/form-js/pull/772