### PR TITLE
Configure FEEL Popup container 

### DIFF
--- a/src/components/PlaygroundComponent.js
+++ b/src/components/PlaygroundComponent.js
@@ -72,6 +72,9 @@ export function PlaygroundComponent(props) {
       data,
       schema,
       editor: { inlinePropertiesPanel: false },
+      propertiesPanel: {
+        feelPopupContainer: rootRef.current
+      },
       ...restProps
     });
   }, []);

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ import { PlaygroundComponent } from './components/PlaygroundComponent';
  *  editorProperties?: FormEditorProperties
  *  exporter?: { name: string, version: string },
  *  layout?: any,
+ *  propertiesPanel?: { parent: Element, feelPopupContainer: Element },
  *  schema: any,
  *  viewerAdditionalModules?: Array<any>,
  *  viewerProperties?: FormProperties,


### PR DESCRIPTION
Depends on https://github.com/bpmn-io/form-js/pull/795
Depends on https://github.com/bpmn-io/properties-panel/pull/280

----

Sets the Popup container to the playground root container.

Demo: https://feel-popup-root--camunda-form-playground.netlify.app/