### PR TITLE
deps: update `@bpmn-io/form-js` and `diagram-js` deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [@camunda/form-playground](https://github.com/camunda/for
 
 **\_Note:** Yet to be released changes appear here.\_
 
+## 0.25.0
+
+* `DEPS`: update to `@bpmn-io/form-js@1.23.0`
+* `DEPS`: update to `diagram-js@15.18.0`
+
+
 ## 0.24.0
 
 * `DEPS`: update to @bpmn-io/form-js@1.19.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,13 @@
       ],
       "dependencies": {
         "classnames": "^2.5.1",
-        "diagram-js": "^15.9.0",
+        "diagram-js": "^15.18.0",
         "min-dash": "^5.0.0",
         "min-dom": "^5.2.0",
         "mitt": "^3.0.1"
       },
       "devDependencies": {
-        "@bpmn-io/form-js": "^1.19.0",
+        "@bpmn-io/form-js": "^1.23.0",
         "@eslint/eslintrc": "^3.3.3",
         "@eslint/js": "^9.38.0",
         "@rollup/plugin-commonjs": "^29.0.0",
@@ -114,7 +114,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -345,29 +344,31 @@
       }
     },
     "node_modules/@bpmn-io/cm-theme": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-ZILgiYzxk3KMvxplUXmdRFQo45/JehDPg5k9tWfehmzUOSE13ssyLPil8uCloMQnb3yyzyOWTjb/wzKXTHlFQw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.2.2.tgz",
+      "integrity": "sha512-9mD7fzzNDNBgseOUC6iRX4mi17LIO2es4zkcHt4e4owQC2Q3YPvqJTJaXqc7kkItloSFsqG2j/1iMJkpvjLv2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@codemirror/language": "^6.3.1",
-        "@codemirror/view": "^6.5.1",
-        "@lezer/highlight": "^1.1.4"
+        "@codemirror/language": "^6.12.3",
+        "@lezer/highlight": "^1.2.3"
       },
-      "workspaces": {
-        "packages": [
-          "preview-themes"
-        ]
+      "engines": {
+        "node": ">= 20.12.0"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
       }
     },
     "node_modules/@bpmn-io/diagram-js-ui": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
-      "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.4.tgz",
+      "integrity": "sha512-I678ZGtoH7z7FgzFhzzppM9ThsJ3Lh83kW3GjhjG3xyYciIPYHMaHK1MABP8F69H9pFZpViM6t4qUo8dwrVz0w==",
       "license": "MIT",
       "dependencies": {
         "htm": "^3.1.1",
-        "preact": "^10.11.2"
+        "preact": "^10.29.2"
       }
     },
     "node_modules/@bpmn-io/draggle": {
@@ -380,25 +381,29 @@
       }
     },
     "node_modules/@bpmn-io/feel-editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-2.2.0.tgz",
-      "integrity": "sha512-K0qoSzBSkxUpIsqt6r4R+vAsEEIED5ra5JJGtjEvTjc8jhc6tu3Jjv6iFPKVuP5i5nDJQZjCufJnT0E4i/zy1Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-2.6.0.tgz",
+      "integrity": "sha512-rI7vFBATeKJVi/KpkfxnclTObAvQGYda0l5eKhNwGIJ8D3+aPQlgdNtxJATX1keXVkqsA1Q/+Yn8Ih+dnC0NMw==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-lint": "^3.1.0",
-        "@bpmn-io/lang-feel": "^3.0.0",
-        "@camunda/feel-builtins": "^0.2.0",
+        "@bpmn-io/lang-feel": "^4.0.2",
+        "@camunda/feel-builtins": "^1.2.0",
         "@codemirror/autocomplete": "^6.20.0",
-        "@codemirror/commands": "^6.10.0",
+        "@codemirror/commands": "^6.10.3",
         "@codemirror/language": "^6.11.3",
-        "@codemirror/lint": "^6.9.2",
-        "@codemirror/state": "^6.5.2",
-        "@codemirror/view": "^6.38.8",
+        "@codemirror/lint": "^6.9.7",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.43.1",
         "@lezer/highlight": "^1.2.3",
-        "min-dom": "^5.2.0"
+        "min-dom": "^5.3.0",
+        "mitt": "^3.0.1"
       },
       "engines": {
         "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@bpmn-io/cm-theme": "^0.2.0"
       }
     },
     "node_modules/@bpmn-io/feel-lint": {
@@ -412,6 +417,41 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@bpmn-io/feelers-editor": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feelers-editor/-/feelers-editor-1.1.0.tgz",
+      "integrity": "sha512-qfrHtk+7hSiNTLMbapbNdV3obsrh92IpIBvAEYqirgLjcI55d0ZUDbdXPt7GA2npVqGGh7GcQwA/EJLR52oC2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/feelers-lint": "^1.0.0",
+        "@bpmn-io/lang-feelers": "^1.0.0",
+        "@codemirror/autocomplete": "^6.20.0",
+        "@codemirror/commands": "^6.10.1",
+        "@codemirror/language": "^6.12.1",
+        "@codemirror/lint": "^6.9.3",
+        "@codemirror/state": "^6.5.4",
+        "@codemirror/view": "^6.39.12",
+        "@lezer/common": "^1.5.1",
+        "@lezer/html": "^1.3.13",
+        "@lezer/markdown": "^1.6.3",
+        "min-dom": "^5.2.0",
+        "mitt": "^3.0.1"
+      },
+      "peerDependencies": {
+        "@bpmn-io/cm-theme": "^0.2.0"
+      }
+    },
+    "node_modules/@bpmn-io/feelers-lint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feelers-lint/-/feelers-lint-1.0.0.tgz",
+      "integrity": "sha512-9McPCub8NBSD3gbAM9fu6laGVvb6U/D8Y5Ar/GGvOaAuJ6W34yP5jaV/on4MALTwmmXTDadZjO2RJJNub3JmwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/feel-lint": "^3.1.0",
+        "@codemirror/language": "^6.12.1",
+        "@codemirror/lint": "^6.9.3"
       }
     },
     "node_modules/@bpmn-io/feelin": {
@@ -430,48 +470,48 @@
       }
     },
     "node_modules/@bpmn-io/form-js": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js/-/form-js-1.19.0.tgz",
-      "integrity": "sha512-ovhSk+LakumtRCRPYH3KEXMO/Ub93mf3+jLqq7ec8+uhuhzca/80y74OrodU4iXamcf82+DDUWFLEo+LC0gRNA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js/-/form-js-1.23.0.tgz",
+      "integrity": "sha512-C5IQiejaeBv5rhhpr9DuyCaPcV8iRAhu0kXxA4RoLgp0l4dwOaqLWm1T8Blw99morRlIGadQoQZaVUE9C/pN3w==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@bpmn-io/form-js-carbon-styles": "^1.19.0",
-        "@bpmn-io/form-js-editor": "^1.19.0",
-        "@bpmn-io/form-js-playground": "^1.19.0",
-        "@bpmn-io/form-js-viewer": "^1.19.0"
+        "@bpmn-io/form-js-carbon-styles": "1.23.0",
+        "@bpmn-io/form-js-editor": "1.23.0",
+        "@bpmn-io/form-js-playground": "1.23.0",
+        "@bpmn-io/form-js-viewer": "1.23.0"
       }
     },
     "node_modules/@bpmn-io/form-js-carbon-styles": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-carbon-styles/-/form-js-carbon-styles-1.19.0.tgz",
-      "integrity": "sha512-k/m0oW/0lIAiTHfQ0GsnAG594/+81/5uS8N65tjQ/vGJjYuDqjwvu4y15v4HlzMCotdBuZbJlOGqhxo2MkuV+g==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-carbon-styles/-/form-js-carbon-styles-1.23.0.tgz",
+      "integrity": "sha512-zQuVCVedf23KfySW/l+gKy7Os2THx4P2hr6Y8r0IjTojjFAOXUER4MdnSpAy+duUHAJ3GwTnej+vnbS9g3rtUQ==",
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/@bpmn-io/form-js-editor": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-editor/-/form-js-editor-1.19.0.tgz",
-      "integrity": "sha512-B/d5UxY/TiuVn3664PBl9KtvqFe5nb7an4c8y7re/hhMnWl7ocKGz/iEusgxMjEJUiARVGpeXF85GeFtgyQrrg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-editor/-/form-js-editor-1.23.0.tgz",
+      "integrity": "sha512-MFE2ORcxvynOiycuLBSbA1+X0TuS9/rR1uGhuLHTL+KfIMNUW/WITavpQFym3JLCtSAKO3AiYg0UARMCpePVOg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@bpmn-io/draggle": "^4.1.2",
-        "@bpmn-io/form-js-viewer": "^1.19.0",
-        "@bpmn-io/properties-panel": "^3.38.0",
+        "@bpmn-io/form-js-viewer": "1.23.0",
+        "@bpmn-io/properties-panel": "^3.45.0",
         "array-move": "^4.0.0",
         "big.js": "^7.0.1",
-        "ids": "^3.0.1",
+        "ids": "^3.0.2",
         "min-dash": "^5.0.0",
-        "min-dom": "^5.2.0",
-        "preact": "^10.5.14"
+        "min-dom": "^5.3.0",
+        "preact": ">=10.5.14 <=10.15.1"
       }
     },
     "node_modules/@bpmn-io/form-js-playground": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-playground/-/form-js-playground-1.19.0.tgz",
-      "integrity": "sha512-RrZleOyJ2bqgWath/fgY4dQefC5cQH3PtKvXqfvHcF04qkKCAFux+rkUjSNxT17OADCByUqFgK/nogCk9g7iqA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-playground/-/form-js-playground-1.23.0.tgz",
+      "integrity": "sha512-mAWKOtvk+VxEOq3CW5ikfEV5fmMci37rLNL9qACfOVrkjGlTd60fjrcJ6Dl2+GtFsg/QvT70LHD7aF4TH1VKuA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@bpmn-io/form-js-editor": "^1.19.0",
-        "@bpmn-io/form-js-viewer": "^1.19.0",
+        "@bpmn-io/form-js-editor": "1.23.0",
+        "@bpmn-io/form-js-viewer": "1.23.0",
         "@codemirror/autocomplete": "^6.20.0",
         "@codemirror/commands": "^6.10.1",
         "@codemirror/lang-json": "^6.0.2",
@@ -488,9 +528,9 @@
       }
     },
     "node_modules/@bpmn-io/form-js-viewer": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-viewer/-/form-js-viewer-1.19.0.tgz",
-      "integrity": "sha512-rUg/IhntnAOsElhr1NLf08v7b/r0gmFo2xr55KxbgivoKmzjEK7JVzDcCkd8UotZd0Kt1wE4bdCp3VJkZE2Xhw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-viewer/-/form-js-viewer-1.23.0.tgz",
+      "integrity": "sha512-5LpP9U35yRIoqi7D2horWUKZgucDu6BII+uV26JEyARbLdHYF+jqj00CqQ1PpPH9dqt002MesUbUKzdbFTlIGg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@bpmn-io/feelin": "^6.1.0",
@@ -498,69 +538,125 @@
         "big.js": "^7.0.1",
         "classnames": "^2.5.1",
         "didi": "^11.0.0",
-        "dompurify": "^3.3.1",
-        "feelers": "^1.5.1",
+        "dompurify": "^3.4.2",
+        "feelers": "^3.1.0",
         "flatpickr": "^4.6.13",
-        "ids": "^3.0.1",
-        "lodash": "^4.17.23",
+        "ids": "^3.0.2",
+        "lodash": "^4.18.1",
         "luxon": "^3.7.2",
-        "marked": "^17.0.1",
+        "marked": "^18.0.3",
         "min-dash": "^5.0.0",
         "preact": "^10.5.14"
       }
     },
     "node_modules/@bpmn-io/lang-feel": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feel/-/lang-feel-3.0.0.tgz",
-      "integrity": "sha512-t/k0z5AW18J7Qz2i/bIFAlvlcS63RuyQB9OQ0YiC1WyMosxXRAnv98LHnVbwirx9vje1DLll85tkBT2B8KLjmQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feel/-/lang-feel-4.0.2.tgz",
+      "integrity": "sha512-rTPeJ77/2nYKbJXpvDmrNXy+opoIpD3Rsch0grCUZAO6xF68r41QeV8SqOdr2yZxD/4gI6YXlQhqh4rqFRDJXA==",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/lezer-feel": "^2.0.0",
-        "@codemirror/autocomplete": "^6.20.0",
-        "@codemirror/language": "^6.11.3",
-        "@lezer/common": "^1.4.0"
+        "@bpmn-io/lezer-feel": "^3.0.1",
+        "@codemirror/autocomplete": "^6.20.3",
+        "@codemirror/language": "^6.12.3",
+        "@lezer/common": "^1.5.2"
       },
       "engines": {
         "node": ">= 20.12.0"
       }
     },
-    "node_modules/@bpmn-io/lezer-feel": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.1.0.tgz",
-      "integrity": "sha512-cvNlgSYlcgFq5hfJpe6R0FD/GbkDox/9Jv8WeLIjCsgmbC9JrrzZcUQ5VrEsbTkznGFtP4vM38k4uGRuKrjffg==",
+    "node_modules/@bpmn-io/lang-feel/node_modules/@bpmn-io/lezer-feel": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-3.0.1.tgz",
+      "integrity": "sha512-+wWg4DP2h8WOEQx2Bz51blsw9dCqKj3kIDKYccABuoAEhzZeDhmm0A2k4ANmm9lf0w5pJmVSYz2djtrbzOvzzA==",
       "license": "MIT",
       "dependencies": {
         "@lezer/highlight": "^1.2.3",
-        "@lezer/lr": "^1.4.7",
+        "@lezer/lr": "^1.4.10",
         "min-dash": "^5.0.0"
       },
       "engines": {
         "node": ">= 20.12.0"
       }
     },
-    "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.38.0.tgz",
-      "integrity": "sha512-o8Oih4ILK93cMyD1FO1rnLL5GvWqbzFM8R14RhEheNUXvfd8/VnwOHpMlXvqlJ5zX8GTN9VBks3jmt7HQf0slg==",
+    "node_modules/@bpmn-io/lang-feelers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feelers/-/lang-feelers-1.0.0.tgz",
+      "integrity": "sha512-VgBDw9cXr62e6Qs6LixQyLiBxxv7Kh8fxKFkYCmHPf/cO8beLQGjnF789wRlhK05yh/CuHi7oN7EYChrFQOHwg==",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/feel-editor": "^2.1.0",
-        "@carbon/icons": "^11.69.0",
+        "@bpmn-io/lezer-feel": "^3.0.0",
+        "@bpmn-io/lezer-feelers": "^1.0.0",
+        "@codemirror/language": "^6.12.1",
+        "@lezer/common": "^1.5.1"
+      }
+    },
+    "node_modules/@bpmn-io/lang-feelers/node_modules/@bpmn-io/lezer-feel": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-3.0.1.tgz",
+      "integrity": "sha512-+wWg4DP2h8WOEQx2Bz51blsw9dCqKj3kIDKYccABuoAEhzZeDhmm0A2k4ANmm9lf0w5pJmVSYz2djtrbzOvzzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/lr": "^1.4.10",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@bpmn-io/lezer-feel": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.5.0.tgz",
+      "integrity": "sha512-09JlwNYeD5YYeFrl0dIFfgQKEL+NNiTyUwEtdcPhfftz1mYa7z+ylOPCv/8Z0GqG7X81uyMFvRZDFCRBFTiUPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/lr": "^1.4.10",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@bpmn-io/lezer-feelers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feelers/-/lezer-feelers-1.0.0.tgz",
+      "integrity": "sha512-P0znH2SY85O7RmOr/FgveFiTREet9DSCf3nH3J/StkI5i7Q384o+GEeTmv58n91FlUknS20KE3T8Yk5Qmab+hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.1",
+        "@lezer/highlight": "^1.1.6",
+        "@lezer/lr": "^1.4.8"
+      }
+    },
+    "node_modules/@bpmn-io/properties-panel": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.47.0.tgz",
+      "integrity": "sha512-tZQRM0x9KLUEFU2FyHCwnYjSq1lbxpY8oCwABFA00IcuyeEDQFDV5DFg7ytTv2qOyWgncZ2xNXPRQ9pydkN2gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/feel-editor": "^2.6.0",
+        "@bpmn-io/feelers-editor": "^1.0.0",
+        "@codemirror/autocomplete": "^6.18.6",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/language": "^6.11.0",
+        "@codemirror/lint": "^6.9.5",
+        "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.28.1",
         "classnames": "^2.5.1",
-        "feelers": "^1.5.1",
-        "focus-trap": "^7.5.2",
+        "focus-trap": "^8.0.0",
         "min-dash": "^5.0.0",
-        "min-dom": "^5.2.0"
+        "min-dom": "^5.3.0"
       },
       "engines": {
         "node": "*"
       }
     },
     "node_modules/@camunda/feel-builtins": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-0.2.0.tgz",
-      "integrity": "sha512-Jusm8x3Onqze9E5Y0lGGdPj66bnFKLYNwDz+uG4otsEXgSL0FpF+koGHK48LkF9Jqo67KaP1y3zr2y/HIWRePw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-1.3.0.tgz",
+      "integrity": "sha512-ZahpLTeBUjnZEMI6Hu/n9e/oTPcJ8DpWmIyJ00tgVNWM1kqAEcMhARK0GthSrD5NXiSVICNHZ7VRTERMq2FmnA==",
       "license": "MIT"
     },
     "node_modules/@camunda/form-playground": {
@@ -568,30 +664,20 @@
       "link": true
     },
     "node_modules/@carbon/grid": {
-      "version": "11.49.0",
-      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.49.0.tgz",
-      "integrity": "sha512-zZfj/sbwJpXboduVFNUXUdV6LmsEH39fNQQMye4V+788sdvs+ErO8L3onBZFpsek5gI4ebwjpWJu2g5szu2+kQ==",
+      "version": "11.56.0",
+      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.56.0.tgz",
+      "integrity": "sha512-AyfagUzgBt4XkFId5Wz4+P33AiNdyIdge8WvH7i0ck8N7xYyFCvmMRUICcd9vesfyz1j9pRHriHISOme9IAKpg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/layout": "^11.47.0",
-        "@ibm/telemetry-js": "^1.5.0"
-      }
-    },
-    "node_modules/@carbon/icons": {
-      "version": "11.74.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-11.74.0.tgz",
-      "integrity": "sha512-tKAUXSgzLvov2gidRb3/U1NvUWKqxfG3anmWMz7WnTj/W3aK6PXpvgfspqPMOnBsnuF5q5H3Csq6XJ99dUZ5ig==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
+        "@carbon/layout": "^11.53.0",
         "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "node_modules/@carbon/layout": {
-      "version": "11.47.0",
-      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.47.0.tgz",
-      "integrity": "sha512-2XR4TVp3uf2IB0WdoZuDcBbc9C8EN/JvZAw9BdHJ3njng8FlUAQUkTFvfoUsJl10868rqA6YeClCElBS4BHofg==",
+      "version": "11.53.0",
+      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.53.0.tgz",
+      "integrity": "sha512-UZz7KEvLxrNJihp8djOqnW5pRVoAahhdT1NuvffBYy78rT+VJx8mpecTGH1G98ydvbtiQYgfz45c0FGZmti6Tg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -599,9 +685,9 @@
       }
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
-      "integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -611,13 +697,13 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.1.tgz",
-      "integrity": "sha512-uWDWFypNdQmz2y1LaNJzK7fL7TYKLeUAU0npEC685OKTF3KcQ2Vu3klIM78D7I6wGhktme0lh3CuQLv0ZCrD9Q==",
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.4.0",
+        "@codemirror/state": "^6.7.0",
         "@codemirror/view": "^6.27.0",
         "@lezer/common": "^1.1.0"
       }
@@ -633,9 +719,9 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.1.tgz",
-      "integrity": "sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -647,20 +733,20 @@
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.3.tgz",
-      "integrity": "sha512-y3YkYhdnhjDBAe0VIA0c4wVoFOvnp8CnAvfLqi0TqotIv92wIlAAP7HELOpLBsKwjAX6W92rSflA6an/2zBvXw==",
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.35.0",
+        "@codemirror/view": "^6.42.0",
         "crelt": "^1.0.5"
       }
     },
     "node_modules/@codemirror/search": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
-      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.1.tgz",
+      "integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -669,21 +755,21 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
-      "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.0.tgz",
+      "integrity": "sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==",
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.39.12",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.12.tgz",
-      "integrity": "sha512-f+/VsHVn/kOA9lltk/GFzuYwVVAKmOnNjxbrhkk3tPHntFqjWeI2TbIXx006YkBkqC10wZ4NsnWXCQiFPeAISQ==",
+      "version": "6.43.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.4.tgz",
+      "integrity": "sha512-YImu23iyKfncJzT7sRy+rEqEhSc8RhOHqDxwy4WzXRKJwYm6iwf/9OJk5ctCAdZ6yi2ZqaGEvmf55fSVqMDrgg==",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/state": "^6.5.0",
+        "@codemirror/state": "^6.7.0",
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
@@ -1288,9 +1374,9 @@
       "license": "MIT"
     },
     "node_modules/@lezer/common": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
-      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
       "license": "MIT"
     },
     "node_modules/@lezer/highlight": {
@@ -1300,6 +1386,17 @@
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/json": {
@@ -1314,18 +1411,18 @@
       }
     },
     "node_modules/@lezer/lr": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
-      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@lezer/markdown": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
-      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.4.tgz",
+      "integrity": "sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.5.0",
@@ -1333,9 +1430,9 @@
       }
     },
     "node_modules/@marijn/find-cluster-break": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
-      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
       "license": "MIT"
     },
     "node_modules/@noble/hashes": {
@@ -2561,7 +2658,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3369,7 +3465,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3528,7 +3623,6 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4065,9 +4159,9 @@
       }
     },
     "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
       "license": "MIT"
     },
     "node_modules/cross-env": {
@@ -4483,17 +4577,17 @@
       "license": "MIT"
     },
     "node_modules/diagram-js": {
-      "version": "15.9.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.9.0.tgz",
-      "integrity": "sha512-9FRoItWkrZnGalrqs0ekwS9wSuHQI2dzO+kJyHKa1hhMJPMBGrjR/cg0XMTpaLo2Vu9/gKL1o19P3sN4/YmIAA==",
+      "version": "15.18.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.18.0.tgz",
+      "integrity": "sha512-aOVeXrjQc1ki0jlrSuwXDoye5nKO6uAtXCtmgQopUvF/aC9aJwoaBOsNvQ2Na9GmMc6X2b3xAefhRChvGgcbgQ==",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/diagram-js-ui": "^0.2.3",
+        "@bpmn-io/diagram-js-ui": "^0.2.4",
         "clsx": "^2.1.1",
         "didi": "^11.0.0",
         "inherits-browser": "^0.1.0",
         "min-dash": "^5.0.0",
-        "min-dom": "^5.2.0",
+        "min-dom": "^5.3.0",
         "object-refs": "^0.4.0",
         "path-intersection": "^4.1.0",
         "tiny-svg": "^4.1.4"
@@ -4591,21 +4685,21 @@
       }
     },
     "node_modules/domify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-2.0.0.tgz",
-      "integrity": "sha512-rmvrrmWQPD/X1A/nPBfIVg4r05792QdG9Z4Prk6oQG0F9zBMDkr0GKAdds1wjb2dq1rTz/ywc4ZxpZbgz0tttg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domify/-/domify-3.0.0.tgz",
+      "integrity": "sha512-bs2yO68JDFOm6rKv8f0EnrM2cENduhRkpqOtt/s5l5JBA/eqGBZCzLPmdYoHtJ6utgLGgcBajFsEQbl12pT0lQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5025,7 +5119,6 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5657,34 +5750,13 @@
       }
     },
     "node_modules/feelers": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/feelers/-/feelers-1.5.1.tgz",
-      "integrity": "sha512-LKIAqtScSfy55Tw62DhBcxIT3k2XnppzWrkmGfsbdad0a+TxMfaLF1CSYhoVRF5FvPAUXvor1Ux/75wtBaDYpA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/feelers/-/feelers-3.1.0.tgz",
+      "integrity": "sha512-xV6FvNe4s1xtJs+D4Yaf1gRNR16czlJwc/1EHpPgjSprLigvS6Uz+FC4geG03mdUGrYVy030kdHz5bFPVbbXEA==",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/cm-theme": "^0.1.0-alpha.2",
-        "@bpmn-io/feel-lint": "^3.1.0",
         "@bpmn-io/feelin": "^6.1.0",
-        "@bpmn-io/lezer-feel": "^2.1.0",
-        "@codemirror/autocomplete": "^6.20.0",
-        "@codemirror/commands": "^6.10.1",
-        "@codemirror/language": "^6.12.1",
-        "@codemirror/lint": "^6.9.3",
-        "@codemirror/state": "^6.5.4",
-        "@codemirror/view": "^6.39.12",
-        "@lezer/common": "^1.5.1",
-        "@lezer/highlight": "^1.1.6",
-        "@lezer/lr": "^1.4.8",
-        "@lezer/markdown": "^1.6.3",
-        "min-dom": "^5.2.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "workspaces": {
-        "packages": [
-          "feelers-playground"
-        ]
+        "@bpmn-io/lezer-feelers": "^1.0.0"
       }
     },
     "node_modules/figures": {
@@ -5842,12 +5914,12 @@
       "license": "ISC"
     },
     "node_modules/focus-trap": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
-      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.2.2.tgz",
+      "integrity": "sha512-qV0g8hRYBqgACcFOH3f9wXc4zPKhr/0z9RI2a6ZijZ72EeBi4g8oBy8zAWuUR1TsMpOzwpUMFvjdasrC41Joug==",
       "license": "MIT",
       "dependencies": {
-        "tabbable": "^6.4.0"
+        "tabbable": "^6.5.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -6560,9 +6632,9 @@
       }
     },
     "node_modules/ids": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ids/-/ids-3.0.1.tgz",
-      "integrity": "sha512-mr0zAgpgA/hzCrHB0DnoTG6xZjNC3ABs4eaksXrpVtfaDatA2SVdDb1ZPLjmKjqzp4kexQRuHXwDWQILVK8FZQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ids/-/ids-3.0.2.tgz",
+      "integrity": "sha512-t6YJP4mdC+GHF96Nbis/4FEANhP/8VWmYMvUuYpXvSdrhg5hpIVbq2XZlOA3UWTbtdwPCi0q7jEXOdHkAnqOnw==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.12"
@@ -7610,7 +7682,6 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -7902,9 +7973,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -8043,9 +8114,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
-      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -8233,12 +8304,12 @@
       "license": "MIT"
     },
     "node_modules/min-dom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-5.2.0.tgz",
-      "integrity": "sha512-shfMH1tFbZCVSx3ECaQV1aGu8fYmGnXEWuItudWRd31DpVJzmVKXFH/Aqgf7YjOmZRgRH5BJafk16oeSbohJDg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-5.3.0.tgz",
+      "integrity": "sha512-0w5FEBgPAyHhmFojW3zxd7we3D+m5XYS3E/06OyvxmbHJoiQVa4Nagj6RWvoAKYRw5xth6cP5TMePc5cR1M9hA==",
       "license": "MIT",
       "dependencies": {
-        "domify": "^2.0.0",
+        "domify": "^3.0.0",
         "min-dash": "^5.0.0"
       }
     },
@@ -9280,7 +9351,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9375,11 +9445,10 @@
       "license": "MIT"
     },
     "node_modules/preact": {
-      "version": "10.26.9",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.9.tgz",
-      "integrity": "sha512-SSjF9vcnF27mJK1XyFMNJzFd5u3pQiATFqoaDy03XuN00u4ziveVVEGt5RKJrDR8MHE/wJo9Nnad56RLzS2RMA==",
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.15.1.tgz",
+      "integrity": "sha512-qs2ansoQEwzNiV5eAcRT1p1EC/dmEzaATVDJNiB3g2sRDWdA7b7MurXdJjB2+/WQktGWZwxvDrnuRFbWuIr64g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -9917,7 +9986,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10194,7 +10262,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11315,9 +11382,9 @@
       }
     },
     "node_modules/tabbable": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
-      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -11603,8 +11670,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -11985,7 +12051,6 @@
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -12137,7 +12202,6 @@
       "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -46,15 +46,18 @@
     }
   ],
   "license": "MIT",
+  "overrides": {
+    "preact": "10.15.1"
+  },
   "dependencies": {
     "classnames": "^2.5.1",
-    "diagram-js": "^15.9.0",
+    "diagram-js": "^15.18.0",
     "min-dash": "^5.0.0",
     "min-dom": "^5.2.0",
     "mitt": "^3.0.1"
   },
   "devDependencies": {
-    "@bpmn-io/form-js": "^1.19.0",
+    "@bpmn-io/form-js": "^1.23.0",
     "@eslint/eslintrc": "^3.3.3",
     "@eslint/js": "^9.38.0",
     "@rollup/plugin-commonjs": "^29.0.0",

--- a/test/spec/CamundaFormPlayground.spec.js
+++ b/test/spec/CamundaFormPlayground.spec.js
@@ -45,12 +45,14 @@ describe('CamundaFormPlayground', function() {
     container = TestContainer.get(this);
   });
 
-  !singleStart && afterEach(function() {
-    if (playground) {
-      playground.destroy();
-      playground = null;
-    }
-  });
+  if (!singleStart) {
+    afterEach(function() {
+      if (playground) {
+        playground.destroy();
+        playground = null;
+      }
+    });
+  }
 
 
   (singleStart ? it.only : it)('should render', async function() {


### PR DESCRIPTION
Update `@bpmn-io/form-js` and `diagram-js` deps

Added additional overide for `"preact": "10.15.1"` because `form-js-editor` (since 1.21) caps `preact` at `>=10.5.14 <=10.15.1` — newer `preact` (≥10.16) reintroduces the drag-and-drop data-loss bug ([form-js#760](https://github.com/bpmn-io/form-js/issues/760)). Meanwhile `diagram-js-ui` (via diagram-js) depends on preact through a caret range that resolves to the latest 10.x (10.29.3). With both in the tree, npm installs a second, nested `preact` for the editor, so the editor mounts on a different `preact` instance than the playground shell → editor renders empty and the drag tests fail.

Pinning `preact` to 10.15.1 for the whole tree keeps a single instance that satisfies the editor's cap and restores a green suite
